### PR TITLE
Add multi device flash support

### DIFF
--- a/install/install.cpp
+++ b/install/install.cpp
@@ -70,6 +70,7 @@ static constexpr int VERIFICATION_PROGRESS_TIME = 60;
 static constexpr float VERIFICATION_PROGRESS_FRACTION = 0.25;
 // The charater used to separate dynamic fingerprints. e.x. sargo|aosp-sargo
 static const char* FINGERPRING_SEPARATOR = "|";
+static const char* DEVICE_SEPARATOR = ",";
 static std::condition_variable finish_log_temperature;
 static bool isInStringList(const std::string& target_token, const std::string& str_list,
                            const std::string& deliminator);
@@ -205,7 +206,7 @@ bool CheckPackageMetadata(const std::map<std::string, std::string>& metadata, Ot
   auto device = android::base::GetProperty("ro.build.product", "");
   auto pkg_device = get_value(metadata, "pre-device");
   // device name can be a | separated list, so need to check
-  if (pkg_device.empty() || !isInStringList(device, pkg_device, FINGERPRING_SEPARATOR)) {
+  if (pkg_device.empty() || !isInStringList(device, pkg_device, DEVICE_SEPARATOR)) {
     LOG(ERROR) << "Package is for product " << pkg_device << " but expected " << device;
     return false;
   }


### PR DESCRIPTION
Adapt to common TARGET_OTA_ASSERT_DEVICE splitter that is ","

This adds support for devices with different hardware versions, example:
Package is for product alioth,aliothin but expected alioth