### PR TITLE
Make our recovery useful again

### DIFF
--- a/etc/init.rc
+++ b/etc/init.rc
@@ -23,6 +23,8 @@ on init
 
     symlink /system/bin /bin
     symlink /system/etc /etc
+    rmdir /sbin
+    symlink /system/bin /sbin
 
     mkdir /sdcard
     mkdir /system

--- a/install/install.cpp
+++ b/install/install.cpp
@@ -47,6 +47,7 @@
 #include <android-base/unique_fd.h>
 
 #include "install/package.h"
+#include "install/snapshot_utils.h"
 #include "install/spl_check.h"
 #include "install/verifier.h"
 #include "install/wipe_data.h"
@@ -344,6 +345,7 @@ static InstallResult TryUpdateBinary(Package* package, bool* wipe_cache,
   bool device_supports_ab = android::base::GetBoolProperty("ro.build.ab_update", false);
   bool ab_device_supports_nonab = true;
   bool device_only_supports_ab = device_supports_ab && !ab_device_supports_nonab;
+  bool device_supports_virtual_ab = android::base::GetBoolProperty("ro.virtual_ab.enabled", false);
 
   const auto current_spl = android::base::GetProperty("ro.build.version.security_patch", "");
   if (ViolatesSPLDowngrade(zip, current_spl)) {
@@ -364,6 +366,15 @@ static InstallResult TryUpdateBinary(Package* package, bool* wipe_cache,
       log_buffer->push_back(android::base::StringPrintf("error: %d", kUpdateBinaryCommandFailure));
       return INSTALL_ERROR;
     }
+  }
+
+  if (!package_is_ab && !logical_partitions_mapped()) {
+    CreateSnapshotPartitions();
+    map_logical_partitions();
+  } else if (package_is_ab && device_supports_virtual_ab && logical_partitions_mapped()) {
+    LOG(ERROR) << "Logical partitions are mapped. "
+               << "Please reboot recovery before installing an OTA update.";
+    return INSTALL_ERROR;
   }
 
   ReadSourceTargetBuild(metadata, log_buffer);

--- a/install/install.cpp
+++ b/install/install.cpp
@@ -81,7 +81,6 @@ bool ReadMetadataFromPackage(ZipArchiveHandle zip, std::map<std::string, std::st
   static constexpr const char* METADATA_PATH = "META-INF/com/android/metadata";
   ZipEntry64 entry;
   if (FindEntry(zip, METADATA_PATH, &entry) != 0) {
-    LOG(ERROR) << "Failed to find " << METADATA_PATH;
     return false;
   }
 
@@ -339,15 +338,11 @@ static InstallResult TryUpdateBinary(Package* package, bool* wipe_cache,
                                      int* max_temperature, RecoveryUI* ui) {
   std::map<std::string, std::string> metadata;
   auto zip = package->GetZipArchiveHandle();
-  if (!ReadMetadataFromPackage(zip, &metadata)) {
-    LOG(ERROR) << "Failed to parse metadata in the zip file";
-    return INSTALL_CORRUPT;
-  }
+  bool has_metadata = ReadMetadataFromPackage(zip, &metadata);
 
-  bool package_is_ab = get_value(metadata, "ota-type") == OtaTypeToString(OtaType::AB);
+  bool package_is_ab = has_metadata && get_value(metadata, "ota-type") == OtaTypeToString(OtaType::AB);
   bool device_supports_ab = android::base::GetBoolProperty("ro.build.ab_update", false);
-  bool ab_device_supports_nonab =
-      android::base::GetBoolProperty("ro.virtual_ab.allow_non_ab", false);
+  bool ab_device_supports_nonab = true;
   bool device_only_supports_ab = device_supports_ab && !ab_device_supports_nonab;
 
   const auto current_spl = android::base::GetProperty("ro.build.version.security_patch", "");

--- a/install/install.cpp
+++ b/install/install.cpp
@@ -544,10 +544,10 @@ static InstallResult VerifyAndInstallPackage(Package* package, bool* wipe_cache,
   ui->ShowProgress(VERIFICATION_PROGRESS_FRACTION, VERIFICATION_PROGRESS_TIME);
 
   // Verify package.
-  if (!verify_package(package, ui)) {
+  /*if (!verify_package(package, ui)) {
     log_buffer->push_back(android::base::StringPrintf("error: %d", kZipVerificationFailure));
     return INSTALL_CORRUPT;
-  }
+  }*/
 
   // Verify and install the contents of the package.
   ui->Print("Installing update...\n");

--- a/recovery_main.cpp
+++ b/recovery_main.cpp
@@ -538,7 +538,7 @@ int main(int argc, char** argv) {
       }
 
       case Device::ENTER_FASTBOOT:
-        if (android::fs_mgr::LogicalPartitionsMapped()) {
+        if (logical_partitions_mapped()) {
           ui->Print("Partitions may be mounted - rebooting to enter fastboot.");
           Reboot("fastboot");
         } else {

--- a/recovery_utils/include/recovery_utils/roots.h
+++ b/recovery_utils/include/recovery_utils/roots.h
@@ -57,4 +57,6 @@ int setup_install_mounts();
 // Returns true if there is /cache in the volumes.
 bool HasCache();
 
+void map_logical_partitions();
+
 bool logical_partitions_mapped();

--- a/recovery_utils/include/recovery_utils/roots.h
+++ b/recovery_utils/include/recovery_utils/roots.h
@@ -56,3 +56,5 @@ int setup_install_mounts();
 
 // Returns true if there is /cache in the volumes.
 bool HasCache();
+
+bool logical_partitions_mapped();

--- a/recovery_utils/roots.cpp
+++ b/recovery_utils/roots.cpp
@@ -47,6 +47,16 @@ using android::fs_mgr::ReadDefaultFstab;
 using android::dm::DeviceMapper;
 using android::dm::DmDeviceState;
 
+static void write_fstab_entry(const FstabEntry& entry, FILE* file) {
+  if (entry.fs_type != "emmc" && !entry.fs_mgr_flags.vold_managed && !entry.blk_device.empty() &&
+      entry.blk_device[0] == '/' && !entry.mount_point.empty() && entry.mount_point[0] == '/') {
+    fprintf(file, "%s ", entry.blk_device.c_str());
+    fprintf(file, "%s ", entry.mount_point.c_str());
+    fprintf(file, "%s ", entry.fs_type.c_str());
+    fprintf(file, "%s 0 0\n", !entry.fs_options.empty() ? entry.fs_options.c_str() : "defaults");
+  }
+}
+
 static Fstab fstab;
 
 constexpr const char* CACHE_ROOT = "/cache";
@@ -55,6 +65,12 @@ void load_volume_table() {
   if (!ReadDefaultFstab(&fstab)) {
     LOG(ERROR) << "Failed to read default fstab";
     return;
+  }
+
+  // Create a boring /etc/fstab so tools like Busybox work
+  FILE* file = fopen("/etc/fstab", "w");
+  if (!file) {
+    LOG(ERROR) << "Unable to create /etc/fstab";
   }
 
   fstab.emplace_back(FstabEntry{
@@ -70,8 +86,15 @@ void load_volume_table() {
     std::cout << "  " << i << " " << entry.mount_point << " "
               << " " << entry.fs_type << " " << entry.blk_device << " " << entry.length
               << std::endl;
+    if (file) {
+      write_fstab_entry(entry, file);
+    }
   }
   std::cout << std::endl;
+
+  if (file) {
+    fclose(file);
+  }
 }
 
 Volume* volume_for_mount_point(const std::string& mount_point) {

--- a/recovery_utils/roots.cpp
+++ b/recovery_utils/roots.cpp
@@ -44,6 +44,8 @@
 using android::fs_mgr::Fstab;
 using android::fs_mgr::FstabEntry;
 using android::fs_mgr::ReadDefaultFstab;
+using android::dm::DeviceMapper;
+using android::dm::DmDeviceState;
 
 static Fstab fstab;
 
@@ -291,8 +293,6 @@ int format_volume(const std::string& volume) {
   return format_volume(volume, "");
 }
 
-static bool logical_partitions_auto_mapped = false;
-
 int setup_install_mounts() {
   if (fstab.empty()) {
     LOG(ERROR) << "can't set up install mounts: no fstab loaded";
@@ -316,16 +316,6 @@ int setup_install_mounts() {
       }
     }
   }
-  // Map logical partitions
-  if (android::base::GetBoolProperty("ro.boot.dynamic_partitions", false) &&
-      !logical_partitions_mapped()) {
-    std::string super_name = fs_mgr_get_super_partition_name();
-    if (!android::fs_mgr::CreateLogicalPartitions("/dev/block/by-name/" + super_name)) {
-      LOG(ERROR) << "Failed to map logical partitions";
-    } else {
-      logical_partitions_auto_mapped = true;
-    }
-  }
   return 0;
 }
 
@@ -335,6 +325,35 @@ bool HasCache() {
   return has_cache;
 }
 
+static bool logical_partitions_auto_mapped = false;
+
+void map_logical_partitions() {
+  if (android::base::GetBoolProperty("ro.boot.dynamic_partitions", false) &&
+      !logical_partitions_mapped()) {
+    std::string super_name = fs_mgr_get_super_partition_name();
+    if (!android::fs_mgr::CreateLogicalPartitions("/dev/block/by-name/" + super_name)) {
+      LOG(ERROR) << "Failed to map logical partitions";
+    } else {
+      logical_partitions_auto_mapped = true;
+    }
+  }
+}
+
+bool dm_find_system() {
+  auto rec = GetEntryForPath(&fstab, android::fs_mgr::GetSystemRoot());
+  if (!rec->fs_mgr_flags.logical) {
+    return false;
+  }
+  // If the fstab entry for system it's a path instead of a name, then it was already mapped
+  if (rec->blk_device[0] != '/') {
+    if (DeviceMapper::Instance().GetState(rec->blk_device) == DmDeviceState::INVALID) {
+      return false;
+    }
+  }
+  return true;
+}
+
 bool logical_partitions_mapped() {
-  return android::fs_mgr::LogicalPartitionsMapped() || logical_partitions_auto_mapped;
+  return android::fs_mgr::LogicalPartitionsMapped() || logical_partitions_auto_mapped ||
+      dm_find_system();
 }

--- a/recovery_utils/roots.cpp
+++ b/recovery_utils/roots.cpp
@@ -37,6 +37,7 @@
 #include <ext4_utils/wipe.h>
 #include <fs_mgr.h>
 #include <fs_mgr/roots.h>
+#include <fs_mgr_dm_linear.h>
 
 #include "otautil/sysutil.h"
 
@@ -290,6 +291,8 @@ int format_volume(const std::string& volume) {
   return format_volume(volume, "");
 }
 
+static bool logical_partitions_auto_mapped = false;
+
 int setup_install_mounts() {
   if (fstab.empty()) {
     LOG(ERROR) << "can't set up install mounts: no fstab loaded";
@@ -313,6 +316,16 @@ int setup_install_mounts() {
       }
     }
   }
+  // Map logical partitions
+  if (android::base::GetBoolProperty("ro.boot.dynamic_partitions", false) &&
+      !logical_partitions_mapped()) {
+    std::string super_name = fs_mgr_get_super_partition_name();
+    if (!android::fs_mgr::CreateLogicalPartitions("/dev/block/by-name/" + super_name)) {
+      LOG(ERROR) << "Failed to map logical partitions";
+    } else {
+      logical_partitions_auto_mapped = true;
+    }
+  }
   return 0;
 }
 
@@ -320,4 +333,8 @@ bool HasCache() {
   CHECK(!fstab.empty());
   static bool has_cache = volume_for_mount_point(CACHE_ROOT) != nullptr;
   return has_cache;
+}
+
+bool logical_partitions_mapped() {
+  return android::fs_mgr::LogicalPartitionsMapped() || logical_partitions_auto_mapped;
 }

--- a/updater/install.cpp
+++ b/updater/install.cpp
@@ -934,8 +934,9 @@ static Value* SetMetadataFn(const char* name, State* state,
 
   struct stat sb;
   if (lstat(args[0].c_str(), &sb) == -1) {
-    return ErrorAbort(state, kSetMetadataFailure, "%s: Error on lstat of \"%s\": %s", name,
-                      args[0].c_str(), strerror(errno));
+    return StringValue("t");
+    /*return ErrorAbort(state, kSetMetadataFailure, "%s: Error on lstat of \"%s\": %s", name,
+                      args[0].c_str(), strerror(errno));*/
   }
 
   struct perm_parsed_args parsed = ParsePermArgs(state, args);

--- a/updater/install.cpp
+++ b/updater/install.cpp
@@ -38,6 +38,9 @@
 #include <linux/xattr.h>
 
 #include <limits>
+
+#include <linux/xattr.h>
+
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
As many have probably noticed you can't really do anything with the built-in recovery apart from flashing OTAs. These sets of commits will bring back the support for stuff like Magisk and also disable the annoying verification check that can't be turned off.
*I added a fix for the A/B in the commit that introduced the runtime check because originally it was fixed in a commit that is not necessary.